### PR TITLE
use unix sockets rather than TCP ports. On Strudel2 setups, we alter …

### DIFF
--- a/m3/rocker-seurat_4.4.3-5.2.1.strudel.yaml.j2
+++ b/m3/rocker-seurat_4.4.3-5.2.1.strudel.yaml.j2
@@ -14,7 +14,7 @@ instactions:
     paramscmd: cat ~/.rstudio-rocker/rserver-{jobid}.json
     client:
       cmd: null
-      redir: ""
+      redir: "{tunnelid}/"
     states:
       - RUNNING
   - name: View log


### PR DESCRIPTION
…the www-root-path which the pathmodifying proxy removes. This allows us to connec top the correct tunnel, rather than another strudel2 app the user might be running